### PR TITLE
fix: Fix build issue with TypeScript rollup task

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "npm install && npm run build",
+    "test": "npm install && npm test"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Request.cjs.js",
   "module": "lib/Request.esm.js",
   "browser": "lib/Request.umd.min.js",
-  "types": "lib/declarations/Request.d.ts",
+  "types": "lib/Request.d.ts",
   "files": [
     "lib"
   ],
@@ -13,11 +13,11 @@
     ".": {
       "import": {
         "default": "./lib/Request.esm.js",
-        "types": "./lib/declarations/Request.d.ts"
+        "types": "./lib/Request.d.ts"
       },
       "require": {
         "default": "./lib/Request.cjs.js",
-        "types": "./lib/declarations/Request.d.ts"
+        "types": "./lib/Request.d.ts"
       }
     },
     "./Logger.umd.js": "./lib/Request.umd.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,7 +24,10 @@ export default [
       },
     ],
     external: ['@jacraig/woodchuck'],
-    plugins: [typescript()],
+    plugins: [typescript({
+      declaration: true,
+      declarationDir: 'lib'
+    })],
   },
   {
     input: 'src/Request.ts',
@@ -39,7 +42,10 @@ export default [
       }
     },
     external: ['@jacraig/woodchuck'],
-    plugins: [typescript()],
+    plugins: [typescript({
+      declaration: true,
+      declarationDir: 'lib'
+    })],
   },
   {
     input: 'src/Request.ts',
@@ -54,6 +60,9 @@ export default [
       }
     },
     external: ['@jacraig/woodchuck'],
-    plugins: [typescript(),terser()],
+    plugins: [typescript({
+      declaration: true,
+      declarationDir: 'lib'
+    }),terser()],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
       "module": "ESNext",                                  /* Specify what module code is generated. */
       "moduleResolution": "bundler",                        /* Specify how TypeScript looks up a file from a given module specifier. */
       "outDir": "lib",                                     /* Specify an output folder for all emitted files. */
-      "declarationDir": "./lib/declarations",               /* Output directory for generated declaration files. */
+      "declarationDir": "./lib",                           /* Output directory for generated declaration files. */
     }
 }


### PR DESCRIPTION
Update the build process to correctly place declaration files in the output directory specified by TypeScript.

* **tsconfig.json**
  - Update `declarationDir` to `./lib` to align with the export directory.
  - Ensure `outDir` is set to `lib`.

* **rollup.config.mjs**
  - Update the `typescript` plugin configuration to output declaration files in the `lib` directory.
  - Ensure the `declaration` and `declarationDir` options are set correctly in the `typescript` plugin configuration.

* **package.json**
  - Update the `types` field to `lib/Request.d.ts` to ensure the declaration files are in the same directory as the export files.
  - Ensure the `files` field includes the `lib` directory.

* **.devcontainer.json**
  - Add a new file with tasks for building and testing the project.

